### PR TITLE
Added missing imports now needed for enums

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -103,13 +103,17 @@ use std::mem;
 use std::c_str;
 use std::time::Duration;
 
+use self::SqliteOk::SQLITE_OK;
+use self::Step::{SQLITE_ROW, SQLITE_DONE};
+
 pub use super::{
-    ColumnType,
-    SQLITE_NULL,
     SqliteError,
     SqliteErrorCode,
     SqliteResult,
 };
+
+pub use super::ColumnType;
+pub use super::ColumnType::SQLITE_NULL;
 
 use ffi;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,8 @@ pub use core::Access;
 pub use core::{DatabaseConnection, PreparedStatement, ResultSet, ResultRow};
 pub use types::{FromSql, ToSql};
 
+use self::SqliteErrorCode::SQLITE_MISUSE;
+
 pub mod core;
 pub mod types;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,11 +2,13 @@
 
 use super::{PreparedStatement, ResultRow};
 use super::{
-    SQLITE_MISMATCH,
     SqliteError,
     SqliteResult,
 };
-use super::{SQLITE_NULL};
+use super::ColumnType::SQLITE_NULL;
+use super::SqliteErrorCode::SQLITE_MISMATCH;
+
+
 use time;
 
 /// Values that can be bound to parameters in prepared statements.


### PR DESCRIPTION
[This push](https://github.com/rust-lang/rust/pull/18973) breaks `master`.  This pull request fixes the problem.
