### PR TITLE
Fix for rustc update, fix a test on Windows

### DIFF
--- a/src/access/mod.rs
+++ b/src/access/mod.rs
@@ -64,13 +64,17 @@ mod tests {
     use std::default::Default;
     use super::ByFilename;
     use core::DatabaseConnection;
-
+    use std::os::tmpdir;
+    use std::path::BytesContainer;
 
     #[test]
     fn open_file_db() {
+        let mut temp_directory = tmpdir();
+        temp_directory.push("db1");
+        let path = temp_directory.container_as_str().unwrap();
         DatabaseConnection::new(
             ByFilename {
-                filename: "/tmp/db1", flags: Default::default()
+                filename: path, flags: Default::default()
             })
             .unwrap();
     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -677,7 +677,6 @@ mod test_opening {
 
 #[cfg(test)]
 mod tests {
-    use std::error::Error;
     use super::{DatabaseConnection, SqliteResult, ResultSet};
     use super::super::{ResultRowAccess};
 

--- a/tests/opening.rs
+++ b/tests/opening.rs
@@ -45,7 +45,7 @@ pub fn main() {
 
     fn lose(why: &str) {
         std::os::set_exit_status(1);
-        writeln!(&mut std::io::stderr(), "{}", why).unwrap()
+        writeln!(&mut std::old_io::stderr(), "{}", why).unwrap()
     }
 
     match cli_access {


### PR DESCRIPTION
The open_file_db test didn't work on Windows, where there is not usually a /tmp directory. 
The rustc changes were: Show has changed to Display and io is now old_io.