### PR TITLE
Fix a NULL dereference

### DIFF
--- a/src/access/mod.rs
+++ b/src/access/mod.rs
@@ -65,7 +65,7 @@ mod tests {
     use super::ByFilename;
     use core::DatabaseConnection;
     use std::os::tmpdir;
-    use std::path::BytesContainer;
+    use std::old_path::BytesContainer;
 
     #[test]
     fn open_file_db() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,9 +88,10 @@ impl ToSql for String {
 
 impl FromSql for String {
     fn from_sql(row: &mut ResultRow, col: ColIx) -> SqliteResult<String> {
-        Ok(row.column_text(col))
+        Ok(row.column_text(col).unwrap_or(String::new()))
     }
 }
+
 
 /// Format of sqlite date strings
 ///
@@ -101,7 +102,7 @@ pub static SQLITE_TIME_FMT: &'static str = "%F %T";
 
 impl FromSql for time::Tm {
     fn from_sql(row: &mut ResultRow, col: ColIx) -> SqliteResult<time::Tm> {
-        let txt = row.column_text(col);
+        let txt = row.column_text(col).unwrap_or(String::new());
         let t = time::strptime(txt.as_slice(), SQLITE_TIME_FMT)
             .unwrap(); // unit tests ensure SQLITE_TIME_FMT is ok
         Ok(t)

--- a/tests/typical.rs
+++ b/tests/typical.rs
@@ -39,7 +39,7 @@ fn typical_usage(conn: &mut DatabaseConnection) -> SqliteResult<String> {
         match results.step() {
             Some(Ok(ref mut row1)) => {
                 let id = row1.column_int(0);
-                let desc_opt = row1.column_text(1);
+                let desc_opt = row1.column_text(1).expect("desc_opt should be non-null");
                 let price = row1.column_int(2);
 
                 assert_eq!(id, 1);


### PR DESCRIPTION
column_text now returns an Option<String> instead of segfaulting when it encounters an SQL null.