### PR TITLE
Fix panic when extracting a misformatted Tm

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -124,7 +124,7 @@ use ffi; // TODO: move to sqlite3-sys crate
 ///
 /// Use `SQLITE_OK as c_int` to decode return values from mod ffi.
 /// See SqliteResult, SqliteError for typical return code handling.
-#[derive(Show, PartialEq, Eq, FromPrimitive, Copy)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy)]
 #[allow(non_camel_case_types)]
 #[allow(missing_docs)]
 pub enum SqliteOk {
@@ -132,7 +132,7 @@ pub enum SqliteOk {
 }
 
 
-#[derive(Show, PartialEq, Eq, FromPrimitive)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive)]
 #[allow(non_camel_case_types)]
 // TODO: use, test this
 enum SqliteLogLevel {
@@ -487,7 +487,7 @@ pub struct ResultSet<'s> {
     statement: &'s mut PreparedStatement<'s>,
 }
 
-#[derive(Show, PartialEq, Eq, FromPrimitive)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive)]
 #[allow(non_camel_case_types)]
 enum Step {
     SQLITE_ROW       = 100,
@@ -726,8 +726,6 @@ mod tests {
 
     #[test]
     fn query_null_string() {
-        let mut db = DatabaseConnection::in_memory().unwrap();
-        let mut stmt = db.prepare("select null").unwrap();
         with_query("select null", |&mut: rows| {
             match rows.step() {
                 Some(Ok(ref mut row)) => {
@@ -735,7 +733,7 @@ mod tests {
                 }
                 _ => { panic!("Expected a row"); }
             }
-        });
+        }).unwrap();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!     SqliteResult,
 //! };
 //! 
-//! #[derive(Show)]
+//! #[derive(Debug)]
 //! struct Person {
 //!     id: i32,
 //!     name: String,
@@ -84,10 +84,9 @@
 
 #![crate_name = "sqlite3"]
 #![crate_type = "lib"]
-#![feature(unsafe_destructor)]
+#![feature(core, unsafe_destructor, std_misc, libc, hash)]
 #![warn(missing_docs)]
 
-#![allow(unstable)]
 extern crate libc;
 extern crate time;
 
@@ -277,7 +276,7 @@ pub type SqliteResult<T> = Result<T, SqliteError>;
 /// `Some(...)` or `None` from `ResultSet::next()`.
 ///
 /// [codes]: http://www.sqlite.org/c3ref/c_abort.html
-#[derive(Show, PartialEq, Eq, FromPrimitive, Copy)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy)]
 #[allow(non_camel_case_types)]
 #[allow(missing_docs)]
 pub enum SqliteErrorCode {
@@ -310,7 +309,7 @@ pub enum SqliteErrorCode {
 }
 
 /// Error results
-#[derive(Show, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SqliteError {
     /// kind of error, by code
     pub kind: SqliteErrorCode,
@@ -341,7 +340,7 @@ impl Error for SqliteError {
 
 
 /// Fundamental Datatypes
-#[derive(Show, PartialEq, Eq, FromPrimitive, Copy)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy)]
 #[allow(non_camel_case_types)]
 #[allow(missing_docs)]
 pub enum ColumnType {

--- a/tests/ex.rs
+++ b/tests/ex.rs
@@ -12,7 +12,7 @@ use sqlite3::{
     SqliteResult,
 };
 
-#[derive(Show)]
+#[derive(Debug)]
 struct Person {
     id: i32,
     name: String,

--- a/tests/opening.rs
+++ b/tests/opening.rs
@@ -1,7 +1,9 @@
+#![feature(core, io, env, os)]
+
 extern crate sqlite3;
 
 use std::default::Default;
-use std::os;
+use std::env;
 
 use sqlite3::{
     Access,
@@ -14,9 +16,8 @@ use sqlite3::{
 use sqlite3::access;
 use sqlite3::access::flags::OPEN_READONLY;
 
-#[allow(unstable)]
 pub fn main() {
-    let args = os::args();
+    let args : Vec<String> = env::args().map(|arg| { arg.to_str().unwrap().to_string() }).collect();
     let usage = "args: [-r] filename";
 
     let cli_access = {
@@ -44,7 +45,7 @@ pub fn main() {
 
 
     fn lose(why: &str) {
-        std::os::set_exit_status(1);
+        env::set_exit_status(1);
         writeln!(&mut std::old_io::stderr(), "{}", why).unwrap()
     }
 
@@ -58,7 +59,7 @@ pub fn main() {
 }
 
 
-#[derive(Show)]
+#[derive(Debug)]
 struct Person {
     id: i32,
     name: String,


### PR DESCRIPTION
If you tried to parse a misformatted time string as a Tm, you would get a panic. Also, some warning fixes are in here.