### PR TITLE
Fix build for rustc changes.

### DIFF
--- a/src/access/mod.rs
+++ b/src/access/mod.rs
@@ -65,16 +65,15 @@ mod tests {
     use super::ByFilename;
     use core::DatabaseConnection;
     use std::env::temp_dir;
-    use std::old_path::BytesContainer;
 
     #[test]
     fn open_file_db() {
         let mut temp_directory = temp_dir();
         temp_directory.push("db1");
-        let path = temp_directory.container_as_str().unwrap();
+        let path = temp_directory.into_os_string().into_string().unwrap();
         DatabaseConnection::new(
             ByFilename {
-                filename: path, flags: Default::default()
+                filename: path.as_slice(), flags: Default::default()
             })
             .unwrap();
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -150,7 +150,7 @@ mod tests {
     fn with_query<T, F>(sql: &str, mut f: F) -> SqliteResult<T>
         where F: FnMut(&mut ResultSet) -> T
     {
-        let mut db = try!(DatabaseConnection::in_memory());
+        let db = try!(DatabaseConnection::in_memory());
         let mut s = try!(db.prepare(sql));
         let mut rows = s.execute();
         Ok(f(&mut rows))
@@ -159,7 +159,7 @@ mod tests {
     #[test]
     fn get_tm() {
         fn go() -> SqliteResult<()> {
-            let mut conn = try!(DatabaseConnection::in_memory());
+            let conn = try!(DatabaseConnection::in_memory());
             let mut stmt = try!(
                 conn.prepare("select datetime('2001-01-01', 'weekday 3', '3 hours')"));
             let mut results = stmt.execute();

--- a/tests/ex.rs
+++ b/tests/ex.rs
@@ -46,7 +46,7 @@ fn io() -> SqliteResult<Vec<Person>> {
                            VALUES ($1, $2)"));
         let changes = try!(conn.update(&mut tx, &[&me.name, &me.time_created]));
         assert_eq!(changes, 1);
-    }
+    };
 
     let mut stmt = try!(conn.prepare("SELECT id, name, time_created FROM person"));
 

--- a/tests/opening.rs
+++ b/tests/opening.rs
@@ -1,9 +1,10 @@
-#![feature(core, io, env)]
+#![feature(core, exit_status)]
 
 extern crate sqlite3;
 
 use std::default::Default;
 use std::env;
+use std::io::Write;
 
 use sqlite3::{
     Access,
@@ -21,9 +22,9 @@ pub fn main() {
     let usage = "args: [-r] filename";
 
     let cli_access = {
-        let ok = |&: flags, dbfile| Some(access::ByFilename { flags: flags, filename: dbfile });
+        let ok = |flags, dbfile| Some(access::ByFilename { flags: flags, filename: dbfile });
 
-        let arg = |&: n| {
+        let arg = |n| {
             if args.len() > n { Some(args[n].as_slice()) }
             else { None }
         };
@@ -46,7 +47,9 @@ pub fn main() {
 
     fn lose(why: &str) {
         env::set_exit_status(1);
-        writeln!(&mut std::old_io::stderr(), "{}", why).unwrap()
+        let stderr = std::io::stderr();
+        let mut stderr_lock = stderr.lock();
+        stderr_lock.write_fmt(format_args!("{}", why)).unwrap()
     }
 
     match cli_access {

--- a/tests/typical.rs
+++ b/tests/typical.rs
@@ -35,7 +35,7 @@ fn typical_usage(conn: &mut DatabaseConnection) -> SqliteResult<String> {
         let mut stmt = try!(conn.prepare(
             "select * from items"));
         let mut results = stmt.execute();
-        match results.step() {
+        let res = match results.step() {
             Ok(Some(ref mut row1)) => {
                 let id = row1.column_int(0);
                 let desc_opt = row1.column_text(1).expect("desc_opt should be non-null");
@@ -49,7 +49,8 @@ fn typical_usage(conn: &mut DatabaseConnection) -> SqliteResult<String> {
             },
             Err(oops) => panic!(oops),
             Ok(None) => panic!("where did our row go?")
-        }
+        };
+        res
     }
 }
 


### PR DESCRIPTION
Previously, PreparedStatement did not actually use its 'db lifetime, so
the lifetime checks behaved as if there was no bound on the lifetime. A
rustc change made that a compile error. Adding a PhantomData there, and so
making the lifetime have to be respected, make a number of other changes
necessary. There are now separate lifetime parameters for statements,
result sets, and rows. Not having separate lifetime parameters would cut
off, (for example) a PreparedStatement's lifetime when it got executed,
even after the ResultSet that came from that execute went out of scope. I
believe that was because the lifetimes got somehow fused together when the
ResultSet was made.

A second change is that prepare() takes a reference instead of a mutable
reference. The compiler was treating the PreparedStatement that came from
the prepare as if it kept ownership of the DatabaseConnection without
that. It seems like there ought to be a way around this, but I didn't find
it.