### PR TITLE
Build on beta, API improvements (?)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ name = "sqlite3"
 
 [dependencies]
 bitflags = "0.1.0"
+enum_primitive = "*"
+libc = "*"
 
 [dependencies.time]
 time = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rust-sqlite"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Dan Connolly <dckc@madmode.com>"]
 keywords = ["database", "sql"]
 

--- a/src/access/mod.rs
+++ b/src/access/mod.rs
@@ -7,7 +7,6 @@
 //!
 //! *TODO: move `mod access` to its own crate so that linking to `sqlite3` doesn't
 //! bring in this ambient authority.*
-#![unstable]
 
 use libc::c_int;
 use std::ptr;
@@ -32,7 +31,6 @@ pub mod flags;
 /// Refer to [Opening A New Database][open] regarding URI filenames.
 ///
 /// [open]: http://www.sqlite.org/c3ref/open.html
-#[stable]
 pub fn open(filename: &str, flags: Option<OpenFlags>) -> SqliteResult<DatabaseConnection> {
     DatabaseConnection::new(
         ByFilename {

--- a/src/core.rs
+++ b/src/core.rs
@@ -685,7 +685,7 @@ fn error_result(
 #[cfg(test)]
 mod test_opening {
     use super::{DatabaseConnection, SqliteResult};
-    use std::time::Duration;
+    use time::Duration;
 
     #[test]
     fn db_construct_typechecks() {

--- a/src/core.rs
+++ b/src/core.rs
@@ -708,7 +708,6 @@ mod test_opening {
 #[cfg(test)]
 mod tests {
     use super::{DatabaseConnection, SqliteResult, ResultSet};
-    use super::super::{ResultRowAccess};
 
     #[test]
     fn stmt_new_types() {
@@ -743,7 +742,7 @@ mod tests {
                     match rows.step() {
                         Ok(Some(ref mut row)) => {
                             count += 1;
-                            sum += row.get(0)
+                            sum += row.column_int(0);
                         },
                         _ => break
                     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -125,7 +125,7 @@ use ffi; // TODO: move to sqlite3-sys crate
 ///
 /// Use `SQLITE_OK as c_int` to decode return values from mod ffi.
 /// See SqliteResult, SqliteError for typical return code handling.
-#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy, Clone)]
 #[allow(non_camel_case_types)]
 #[allow(missing_docs)]
 pub enum SqliteOk {
@@ -187,10 +187,9 @@ fn maybe<T>(choice: bool, x: T) -> Option<T> {
     if choice { Some(x) } else { None }
 }
 
-use std::error::FromError;
 use std::ffi::NulError;
-impl FromError<NulError> for SqliteError {
-    fn from_error(_: NulError) -> SqliteError {
+impl From<NulError> for SqliteError {
+    fn from(_: NulError) -> SqliteError {
         SqliteError{
             kind: SqliteErrorCode::SQLITE_MISUSE,
             desc: "Sql string contained an internal 0 byte",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,7 +413,8 @@ mod bind_tests {
         let db = try!(DatabaseConnection::in_memory());
         let mut s = try!(db.prepare(sql));
         let mut rows = s.execute();
-        Ok(f(&mut rows))
+        let x = f(&mut rows);
+        return Ok(x);
     }
 
     #[test]
@@ -429,7 +430,7 @@ mod bind_tests {
                     match rows.step() {
                         Ok(Some(ref mut row)) => {
                             count += 1;
-                            sum += row.get("col1")
+                            sum += row.column_int(0);
                         },
                         _ => break
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@
 
 #![crate_name = "sqlite3"]
 #![crate_type = "lib"]
-#![feature(convert, core, collections, unsafe_destructor, std_misc, libc)]
+#![feature(core, collections, unsafe_destructor, std_misc, libc)]
 #![warn(missing_docs)]
 
 
@@ -275,7 +275,7 @@ pub type SqliteResult<T> = Result<T, SqliteError>;
 /// `Some(...)` or `None` from `ResultSet::next()`.
 ///
 /// [codes]: http://www.sqlite.org/c3ref/c_abort.html
-#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy, Clone)]
 #[allow(non_camel_case_types)]
 #[allow(missing_docs)]
 pub enum SqliteErrorCode {
@@ -339,7 +339,7 @@ impl Error for SqliteError {
 
 
 /// Fundamental Datatypes
-#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy, Clone)]
 #[allow(non_camel_case_types)]
 #[allow(missing_docs)]
 pub enum ColumnType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,15 +84,16 @@
 
 #![crate_name = "sqlite3"]
 #![crate_type = "lib"]
-#![feature(core, collections, unsafe_destructor, std_misc, libc)]
 #![warn(missing_docs)]
-
 
 extern crate libc;
 extern crate time;
 
 #[macro_use]
 extern crate bitflags;
+
+#[macro_use]
+extern crate enum_primitive;
 
 use std::error::{Error};
 use std::fmt::Display;
@@ -275,36 +276,38 @@ pub type SqliteResult<T> = Result<T, SqliteError>;
 /// `Some(...)` or `None` from `ResultSet::next()`.
 ///
 /// [codes]: http://www.sqlite.org/c3ref/c_abort.html
-#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy, Clone)]
-#[allow(non_camel_case_types)]
-#[allow(missing_docs)]
-pub enum SqliteErrorCode {
-    SQLITE_ERROR     =  1,
-    SQLITE_INTERNAL  =  2,
-    SQLITE_PERM      =  3,
-    SQLITE_ABORT     =  4,
-    SQLITE_BUSY      =  5,
-    SQLITE_LOCKED    =  6,
-    SQLITE_NOMEM     =  7,
-    SQLITE_READONLY  =  8,
-    SQLITE_INTERRUPT =  9,
-    SQLITE_IOERR     = 10,
-    SQLITE_CORRUPT   = 11,
-    SQLITE_NOTFOUND  = 12,
-    SQLITE_FULL      = 13,
-    SQLITE_CANTOPEN  = 14,
-    SQLITE_PROTOCOL  = 15,
-    SQLITE_EMPTY     = 16,
-    SQLITE_SCHEMA    = 17,
-    SQLITE_TOOBIG    = 18,
-    SQLITE_CONSTRAINT= 19,
-    SQLITE_MISMATCH  = 20,
-    SQLITE_MISUSE    = 21,
-    SQLITE_NOLFS     = 22,
-    SQLITE_AUTH      = 23,
-    SQLITE_FORMAT    = 24,
-    SQLITE_RANGE     = 25,
-    SQLITE_NOTADB    = 26
+enum_from_primitive! {
+    #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+    #[allow(non_camel_case_types)]
+    #[allow(missing_docs)]
+    pub enum SqliteErrorCode {
+        SQLITE_ERROR     =  1,
+        SQLITE_INTERNAL  =  2,
+        SQLITE_PERM      =  3,
+        SQLITE_ABORT     =  4,
+        SQLITE_BUSY      =  5,
+        SQLITE_LOCKED    =  6,
+        SQLITE_NOMEM     =  7,
+        SQLITE_READONLY  =  8,
+        SQLITE_INTERRUPT =  9,
+        SQLITE_IOERR     = 10,
+        SQLITE_CORRUPT   = 11,
+        SQLITE_NOTFOUND  = 12,
+        SQLITE_FULL      = 13,
+        SQLITE_CANTOPEN  = 14,
+        SQLITE_PROTOCOL  = 15,
+        SQLITE_EMPTY     = 16,
+        SQLITE_SCHEMA    = 17,
+        SQLITE_TOOBIG    = 18,
+        SQLITE_CONSTRAINT= 19,
+        SQLITE_MISMATCH  = 20,
+        SQLITE_MISUSE    = 21,
+        SQLITE_NOLFS     = 22,
+        SQLITE_AUTH      = 23,
+        SQLITE_FORMAT    = 24,
+        SQLITE_RANGE     = 25,
+        SQLITE_NOTADB    = 26
+    }
 }
 
 /// Error results
@@ -339,17 +342,18 @@ impl Error for SqliteError {
 
 
 /// Fundamental Datatypes
-#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy, Clone)]
-#[allow(non_camel_case_types)]
-#[allow(missing_docs)]
-pub enum ColumnType {
-    SQLITE_INTEGER = 1,
-    SQLITE_FLOAT   = 2,
-    SQLITE_TEXT    = 3,
-    SQLITE_BLOB    = 4,
-    SQLITE_NULL    = 5
+enum_from_primitive! {
+    #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+    #[allow(non_camel_case_types)]
+    #[allow(missing_docs)]
+    pub enum ColumnType {
+        SQLITE_INTEGER = 1,
+        SQLITE_FLOAT   = 2,
+        SQLITE_TEXT    = 3,
+        SQLITE_BLOB    = 4,
+        SQLITE_NULL    = 5
+    }
 }
-
 
 #[cfg(test)]
 mod bind_tests {

--- a/src/types.rs
+++ b/src/types.rs
@@ -93,6 +93,12 @@ impl FromSql for String {
     }
 }
 
+impl<'a> ToSql for &'a [u8] {
+    fn to_sql(&self, s: &mut PreparedStatement, ix: ParamIx) -> SqliteResult<()> {
+        s.bind_blob(ix, *self)
+    }
+}
+
 impl FromSql for Vec<u8> {
     fn from_sql(row: &mut ResultRow, col: ColIx) -> SqliteResult<Vec<u8>> {
         Ok(row.column_blob(col).unwrap_or(Vec::new()))

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,8 +7,6 @@ use super::{
 };
 use super::ColumnType::SQLITE_NULL;
 
-use std::error::FromError;
-
 use time;
 
 /// Values that can be bound to parameters in prepared statements.
@@ -130,8 +128,8 @@ impl FromSql for time::Tm {
     }
 }
 
-impl FromError<time::ParseError> for SqliteError {
-    fn from_error(err: time::ParseError) -> SqliteError {
+impl From<time::ParseError> for SqliteError {
+    fn from(err: time::ParseError) -> SqliteError {
         SqliteError {
             kind: SqliteErrorCode::SQLITE_MISMATCH,
             desc: "Time did not match expected format",

--- a/src/types.rs
+++ b/src/types.rs
@@ -62,6 +62,16 @@ impl FromSql for f64 {
     fn from_sql(row: &mut ResultRow, col: ColIx) -> SqliteResult<f64> { Ok(row.column_double(col)) }
 }
 
+impl ToSql for bool {
+    fn to_sql(&self, s: &mut PreparedStatement, ix: ParamIx) -> SqliteResult<()> {
+        s.bind_int(ix, if *self { 1 } else { 0 })
+    }
+}
+
+impl FromSql for bool {
+    fn from_sql(row: &mut ResultRow, col: ColIx) -> SqliteResult<bool> { Ok(row.column_int(col)!=0) }
+}
+
 impl<T: ToSql + Clone> ToSql for Option<T> {
     fn to_sql(&self, s: &mut PreparedStatement, ix: ParamIx) -> SqliteResult<()> {
         match (*self).clone() {

--- a/tests/ex.rs
+++ b/tests/ex.rs
@@ -6,10 +6,10 @@ use time::Timespec;
 
 use sqlite3::{
     DatabaseConnection,
-    DatabaseUpdate,
     Query,
     ResultRowAccess,
     SqliteResult,
+    StatementUpdate,
 };
 
 #[derive(Debug)]
@@ -44,7 +44,7 @@ fn io() -> SqliteResult<Vec<Person>> {
     {
         let mut tx = try!(conn.prepare("INSERT INTO person (name, time_created)
                            VALUES ($1, $2)"));
-        let changes = try!(conn.update(&mut tx, &[&me.name, &me.time_created]));
+        let changes = try!(tx.update(&[&me.name, &me.time_created]));
         assert_eq!(changes, 1);
     };
 

--- a/tests/opening.rs
+++ b/tests/opening.rs
@@ -1,4 +1,4 @@
-#![feature(convert, exit_status)]
+#![feature(exit_status)]
 
 extern crate sqlite3;
 

--- a/tests/opening.rs
+++ b/tests/opening.rs
@@ -1,5 +1,3 @@
-#![feature(exit_status)]
-
 extern crate sqlite3;
 
 use std::default::Default;
@@ -46,7 +44,7 @@ pub fn main() {
 
 
     fn lose(why: &str) {
-        env::set_exit_status(1);
+        // FIXME: Set the exit status once that is stabilized
         let stderr = std::io::stderr();
         let mut stderr_lock = stderr.lock();
         stderr_lock.write_fmt(format_args!("{}", why)).unwrap()

--- a/tests/opening.rs
+++ b/tests/opening.rs
@@ -7,10 +7,10 @@ use std::io::Write;
 use sqlite3::{
     Access,
     DatabaseConnection,
-    DatabaseUpdate,
     Query,
     ResultRowAccess,
     SqliteResult,
+    StatementUpdate,
 };
 use sqlite3::access;
 use sqlite3::access::flags::OPEN_READONLY;
@@ -75,7 +75,7 @@ fn make_people(conn: &mut DatabaseConnection) -> SqliteResult<Vec<Person>> {
     {
         let mut tx = try!(conn.prepare("INSERT INTO person (id, name)
                            VALUES (0, 'Dan')"));
-        let changes = try!(conn.update(&mut tx, &[]));
+        let changes = try!(tx.update(&[]));
         assert_eq!(changes, 1);
     }
 


### PR DESCRIPTION
This is kind of a catch-all pull request for the things I have been doing to this library as I use it in my project. I can break it into smaller pull requests if you would prefer. It has 4 main points:

- The library builds and works on Beta
- DatabaseConnection and PreparedStatement no longer have lifetime parameters. This makes creating a struct that holds a DatabaseConnection and a PreparedStatement much nicer. Unless a user of this library does something unusual, I believe they will never have to write <'a>. This works by resource counting the actual database handle instead of having it owned by the DatabaseConnection. The performance cost for this is small, since it the counting only happens on open/close/prepare/finalize, and it doesn't need to use the atomic reference count type.
- DatabaseUpdate has been changed to StatementUpdate. It is no longer useful to pass the DatabaseConnection as well as the PreparedStatement when you want to run an update, and it makes for cleaner calling as well.
- ToSql/FromSql is implemented for bool. ToSql is implemented for [u8].