### PR TITLE
Add zero-copy column getters and fix potential non-UTF8 Strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 
 name = "rust-sqlite"
 version = "0.2.0"
-authors = ["Dan Connolly <dckc@madmode.com>"]
+authors = [
+  "Dan Connolly <dckc@madmode.com>",
+  "Peter Reid <peter.d.reid@gmail.com>"
+]
 keywords = ["database", "sql"]
 
 exclude = [


### PR DESCRIPTION
Add zero-copy column getters and fix potential non-UTF8 Strings

Sqlite3's notion of text corresponds more closely to Rust's notion of
[u8]s than strs in two important ways:
 - Sqlite3's text, like [u8]s and unlike strs, can contain non-UTF8
   sequences.
 - Sqlite3's text, unlike strs, must be null-terminated.

This makes sqlite3_column_blob work at least as well as
sqlite3_column_text for getting a str into Rust. Never using
sqlite3_column_text has another advantage: mixing calls to
sqlite3_column_blob and sqlite3_column_text may cause the underlying
buffer to be reallocated, invalidating the old buffer. By only ever
calling the _blob variant, the buffer returned will be valid for as long
as the row. This makes it possible to safely expose zero-copy column
getters for &[u8] and &str.

And I added myself to the authors list.