### PR TITLE
Fix warning (Sized trait required by Result<Self>)

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -23,9 +23,8 @@ pub trait ToSql {
 ///
 /// [column]: http://www.sqlite.org/c3ref/column_blob.html
 ///
-///   - *TODO: consider a `types` submodule*
 ///   - *TODO: many more implementors, including Option<T>*
-pub trait FromSql {
+pub trait FromSql : Sized {
     /// Try to extract a `Self` type value from the `col`th colum of a `ResultRow`.
     fn from_sql(row: &ResultRow, col: ColIx) -> SqliteResult<Self>;
 }


### PR DESCRIPTION
Fixes this warning:

```
   Compiling rust-sqlite v0.2.0 (file:///home/asommer/dev/extern/rust-sqlite3)
src/types.rs:30:5: 30:68 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/types.rs:30     fn from_sql(row: &ResultRow, col: ColIx) -> SqliteResult<Self>;
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/types.rs:30:5: 30:68 help: run `rustc --explain E0277` to see a detailed explanation
src/types.rs:30:5: 30:68 note: `Self` does not have a constant size known at compile-time
src/types.rs:30:5: 30:68 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/types.rs:30     fn from_sql(row: &ResultRow, col: ColIx) -> SqliteResult<Self>;
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/types.rs:30:5: 30:68 note: required by `core::result::Result`
```