### PR TITLE
Fix specification of dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,4 @@ name = "sqlite3"
 bitflags = "^0.1.0"
 enum_primitive = "0.1.0"
 libc = "0.2.5"
-
-[dependencies.time]
 time = "^0.1.5"

--- a/src/core.rs
+++ b/src/core.rs
@@ -467,9 +467,9 @@ impl PreparedStatement {
         let ix = i as c_int;
         // SQLITE_TRANSIENT => SQLite makes a copy
         let transient = unsafe { mem::transmute(-1 as isize) };
-        let c_value = str_charstar(value).as_ptr();
+        let c_value = str_charstar(value);
         let len = value.len() as c_int;
-        let r = unsafe { ffi::sqlite3_bind_text(self.stmt, ix, c_value, len, transient) };
+        let r = unsafe { ffi::sqlite3_bind_text(self.stmt, ix, c_value.as_ptr(), len, transient) };
         decode_result(r, "sqlite3_bind_text", self.detail_db())
     }
 


### PR DESCRIPTION
Was always incorrect, and from Rust 1.9 or so, Cargo will actually warn about it (will become an error at some point).

It must either be

``` toml
[dependencies.time]
version = "^0.1.5"
```

or just plain below "[dependencies]":

``` toml
[dependencies]
time = "^0.1.5"
```
